### PR TITLE
TFLM: implement new memory planning API.

### DIFF
--- a/tensorflow/lite/micro/BUILD
+++ b/tensorflow/lite/micro/BUILD
@@ -127,6 +127,7 @@ tflite_micro_cc_test(
     deps = [
         ":micro_framework",
         ":micro_utils",
+        "//tensorflow/lite/kernels:kernel_util",
         "//tensorflow/lite/micro/testing:micro_test",
     ],
 )

--- a/tensorflow/lite/micro/micro_allocator.cc
+++ b/tensorflow/lite/micro/micro_allocator.cc
@@ -95,24 +95,58 @@ TfLiteStatus AllocateVariables(
   return kTfLiteOk;
 }
 
-AllocationInfo* AllocateAndCalculateAllocationInfo(
-    ErrorReporter* error_reporter, size_t allocation_info_size,
-    const SubGraph* subgraph, TfLiteTensor* runtime_tensors,
-    SimpleMemoryAllocator* allocator) {
-  AllocationInfo* allocation_info = reinterpret_cast<AllocationInfo*>(
-      allocator->AllocateFromTail(sizeof(AllocationInfo) * allocation_info_size,
-                                  alignof(AllocationInfo)));
-  if (allocation_info == nullptr) {
-    TF_LITE_REPORT_ERROR(
-        error_reporter,
-        "Failed to allocate memory for allocation_info, %d bytes required",
-        sizeof(TfLiteTensor) * allocation_info_size);
-    return nullptr;
+// A helper class to construct AllocationInfo array. This array contains the
+// lifetime of tensors / scratch_buffer and will be used to calculate the memory
+// plan. Methods need to be called in order from `Init`, `Add*`, to `Finish`.
+class AllocationInfoBuilder {
+ public:
+  AllocationInfoBuilder(ErrorReporter* reporter,
+                        SimpleMemoryAllocator* allocator)
+      : reporter_(reporter), allocator_(allocator) {}
+
+  TfLiteStatus Init(size_t tensor_count, size_t scratch_buffer_count) {
+    tensor_count_ = tensor_count;
+    buffer_count_ = scratch_buffer_count;
+    return Allocate();
   }
 
-  // Set up the runtime data structures for all tensors.
-  for (size_t i = 0; i < allocation_info_size; ++i) {
-    AllocationInfo* current = &allocation_info[i];
+  TfLiteStatus AddTensors(const SubGraph* subgraph,
+                          TfLiteTensor* runtime_tensors);
+  TfLiteStatus AddScratchBuffers(internal::ScratchBufferHandle* buffer_handles);
+
+  const AllocationInfo* Finish() { return info_; }
+  size_t Size() { return tensor_count_ + buffer_count_; }
+
+ private:
+  // Allocate the output AllocationInfo array from the allocator_;
+  TfLiteStatus Allocate();
+
+  ErrorReporter* reporter_ = nullptr;
+  SimpleMemoryAllocator* allocator_ = nullptr;
+  size_t tensor_count_ = 0;
+  size_t buffer_count_ = 0;
+  AllocationInfo* info_ = nullptr;
+};
+
+TfLiteStatus AllocationInfoBuilder::Allocate() {
+  size_t bytes = sizeof(AllocationInfo) * Size();
+  info_ = reinterpret_cast<AllocationInfo*>(
+      allocator_->AllocateFromTail(bytes, alignof(AllocationInfo)));
+  if (info_ == nullptr) {
+    TF_LITE_REPORT_ERROR(
+        reporter_,
+        "Failed to allocate memory for allocation_info, %d bytes required",
+        bytes);
+    return kTfLiteError;
+  }
+  return kTfLiteOk;
+}
+
+TfLiteStatus AllocationInfoBuilder::AddTensors(const SubGraph* subgraph,
+                                               TfLiteTensor* runtime_tensors) {
+  // Set up allocation info for all tensors.
+  for (size_t i = 0; i < tensor_count_; ++i) {
+    AllocationInfo* current = &info_[i];
     // TfLiteTensor.uint8 field is deprecated so use .data field instead.
     current->output_ptr = &(runtime_tensors[i].data.data);
     current->bytes = runtime_tensors[i].bytes;
@@ -124,14 +158,14 @@ AllocationInfo* AllocateAndCalculateAllocationInfo(
 
   for (size_t i = 0; i < subgraph->inputs()->size(); ++i) {
     const int tensor_index = subgraph->inputs()->Get(i);
-    AllocationInfo* current = &allocation_info[tensor_index];
+    AllocationInfo* current = &info_[tensor_index];
     current->first_created = 0;
   }
 
   // Mark all outputs as persistent to the end of the invocation.
   for (size_t i = 0; i < subgraph->outputs()->size(); ++i) {
     const int tensor_index = subgraph->outputs()->Get(i);
-    AllocationInfo* current = &allocation_info[tensor_index];
+    AllocationInfo* current = &info_[tensor_index];
     current->last_used = subgraph->operators()->size() - 1;
   }
 
@@ -140,14 +174,14 @@ AllocationInfo* AllocateAndCalculateAllocationInfo(
     const auto* op = subgraph->operators()->Get(i);
     for (size_t n = 0; n < op->inputs()->size(); ++n) {
       const int tensor_index = op->inputs()->Get(n);
-      AllocationInfo* current = &allocation_info[tensor_index];
+      AllocationInfo* current = &info_[tensor_index];
       if (((current->last_used == -1) || (current->last_used < i))) {
         current->last_used = i;
       }
     }
     for (size_t n = 0; n < op->outputs()->size(); ++n) {
       const int tensor_index = op->outputs()->Get(n);
-      AllocationInfo* current = &allocation_info[tensor_index];
+      AllocationInfo* current = &info_[tensor_index];
       if ((current->first_created == -1) || (current->first_created > i)) {
         current->first_created = i;
       }
@@ -155,8 +189,8 @@ AllocationInfo* AllocateAndCalculateAllocationInfo(
   }
 
   // Work out which tensors need to be allocated.
-  for (size_t i = 0; i < allocation_info_size; ++i) {
-    AllocationInfo* current = &allocation_info[i];
+  for (size_t i = 0; i < tensor_count_; ++i) {
+    AllocationInfo* current = &info_[i];
     const bool is_read_only =
         (current->first_created == -1) && (current->last_used != -1);
     if (is_read_only) {
@@ -167,16 +201,31 @@ AllocationInfo* AllocateAndCalculateAllocationInfo(
         ((current->first_created == -1) || (current->last_used == -1));
     if (has_partial_lifetime && current->needs_allocating) {
       TF_LITE_REPORT_ERROR(
-          error_reporter,
+          reporter_,
           "Logic error in memory planner, tensor %d has an invalid lifetime: "
           "first_created: %d, last_used: %d",
           i, current->first_created, current->last_used);
-      return nullptr;
+      return kTfLiteError;
     }
-  }  // namespace
+  }
+  return kTfLiteOk;
+}
 
-  return allocation_info;
-}  // namespace tflite
+TfLiteStatus AllocationInfoBuilder::AddScratchBuffers(
+    internal::ScratchBufferHandle* buffer_handles) {
+  // Set up allocation info for buffers.
+  for (size_t i = tensor_count_; i < tensor_count_ + buffer_count_; ++i) {
+    AllocationInfo* current = &info_[i];
+    internal::ScratchBufferHandle* handle =
+        &(buffer_handles[i - tensor_count_]);
+    current->output_ptr = reinterpret_cast<void**>(&handle->data);
+    current->bytes = handle->bytes;
+    current->first_created = handle->node_idx;
+    current->last_used = handle->node_idx;
+    current->needs_allocating = true;
+  }
+  return kTfLiteOk;
+}
 
 TfLiteStatus CreatePlan(ErrorReporter* error_reporter, MemoryPlanner* planner,
                         const AllocationInfo* allocation_info,
@@ -197,12 +246,12 @@ TfLiteStatus CreatePlan(ErrorReporter* error_reporter, MemoryPlanner* planner,
 
 TfLiteStatus CommitPlan(ErrorReporter* error_reporter, MemoryPlanner* planner,
                         uint8_t* starting_point,
-                        AllocationInfo* allocation_info,
+                        const AllocationInfo* allocation_info,
                         size_t allocation_info_size) {
   // Figure out the actual memory addresses for each buffer, based on the plan.
   int planner_index = 0;
   for (size_t i = 0; i < allocation_info_size; ++i) {
-    AllocationInfo* current = &allocation_info[i];
+    const AllocationInfo* current = &allocation_info[i];
     if (current->needs_allocating) {
       int offset = -1;
       TF_LITE_ENSURE_STATUS(
@@ -317,9 +366,7 @@ TfLiteStatus InitializeRuntimeTensor(
 
     result->quantization = {kTfLiteAffineQuantization, quantization};
   }
-  if (flatbuffer_tensor.name() != nullptr) {
-    result->name = flatbuffer_tensor.name()->c_str();
-  }
+  result->name = flatbuffer_tensor.name()->c_str();
   return kTfLiteOk;
 }
 }  // namespace internal
@@ -465,13 +512,9 @@ TfLiteStatus MicroAllocator::AllocateNodeAndRegistrations(
     *node = {};
     node->inputs = inputs_array;
     node->outputs = outputs_array;
-    // This is OK for now as temporary array is not in used.
-    node->temporaries = nullptr;
-    node->user_data = nullptr;  // Will be filled in after `init`
     node->builtin_data = reinterpret_cast<void*>(builtin_data);
     node->custom_initial_data = custom_data;
     node->custom_initial_data_size = custom_data_size;
-    node->delegate = nullptr;
   }
   *node_and_registrations = output;
   return kTfLiteOk;
@@ -482,30 +525,33 @@ TfLiteStatus MicroAllocator::FinishTensorAllocation() {
     return kTfLiteError;
   }
 
-  // Create static memory plan. AllocationInfo is needed for creating the plan
-  // but is thrown away afterwards.
+  // Create static memory plan
+  // 1. Calculate AllocationInfo to know the lifetime of each tensor/buffer.
+  // 2. Add them into the planner (such as the GreedyMemoryPlanner).
+  // 3. Static memory planning using the planner.
+  // 4. Set tensor/buffer pointers based on the offsets from the previous step.
+  // Note that AllocationInfo is only needed for creating the plan. It will be
+  // thrown away when the child allocator (tmp_allocator) goes out of scope.
   {
     SimpleMemoryAllocator tmp_allocator =
         memory_allocator_->CreateChildAllocator();
-    size_t allocation_info_size = tensors_->size();
-    AllocationInfo* allocation_info = AllocateAndCalculateAllocationInfo(
-        error_reporter_, allocation_info_size, subgraph_, context_->tensors,
-        &tmp_allocator);
-    if (allocation_info == nullptr) {
-      return kTfLiteError;
-    }
+
+    AllocationInfoBuilder builder(error_reporter_, &tmp_allocator);
+    TF_LITE_ENSURE_STATUS(
+        builder.Init(tensors_->size(), scratch_buffer_count_));
+    TF_LITE_ENSURE_STATUS(builder.AddTensors(subgraph_, context_->tensors));
+    TF_LITE_ENSURE_STATUS(builder.AddScratchBuffers(scratch_buffer_handles_));
+    const AllocationInfo* allocation_info = builder.Finish();
 
     uint8_t* aligned_arena = memory_allocator_->GetBuffer();
     size_t arena_size = memory_allocator_->GetMaxBufferSize();
-
     // Remaining arena size that memory planner can use for calculating offsets.
     // The remaining size should always be a positive number since the parent
     // allocator is always bigger than the child allocator.
     size_t remaining_arena_size = arena_size - tmp_allocator.GetDataSize();
     GreedyMemoryPlanner planner(aligned_arena, remaining_arena_size);
-    TF_LITE_ENSURE_STATUS(CreatePlan(error_reporter_, &planner, allocation_info,
-                                     allocation_info_size));
-
+    TF_LITE_ENSURE_STATUS(
+        CreatePlan(error_reporter_, &planner, allocation_info, builder.Size()));
     // Actual size available for placing tensors. This includes memory held by
     // the tensor info array, which will be released.
     size_t actual_available_arena_size =
@@ -521,7 +567,7 @@ TfLiteStatus MicroAllocator::FinishTensorAllocation() {
     }
 
     TF_LITE_ENSURE_STATUS(CommitPlan(error_reporter_, &planner, aligned_arena,
-                                     allocation_info, allocation_info_size));
+                                     allocation_info, builder.Size()));
   }
 
   // Data in variables need to be kept for the next invocation so allocating
@@ -536,6 +582,62 @@ TfLiteStatus MicroAllocator::FinishTensorAllocation() {
 
   active_ = false;
   return kTfLiteOk;
+}
+
+TfLiteStatus MicroAllocator::AllocatePersistentBuffer(size_t bytes,
+                                                      void** ptr) {
+  uint8_t* data = memory_allocator_->AllocateFromTail(bytes, kBufferAlignment);
+  if (data == nullptr) {
+    TF_LITE_REPORT_ERROR(error_reporter_,
+                         "Failed to allocate persistent buffer of size %d",
+                         bytes);
+    return kTfLiteError;
+  }
+  (*ptr) = data;
+  return kTfLiteOk;
+}
+
+TfLiteStatus MicroAllocator::RequestScratchBufferInArena(int node_id,
+                                                         size_t bytes,
+                                                         int* buffer_idx) {
+  // A sanity check to make sure scratch_buffer_handles_ is contiguous.
+  if (reinterpret_cast<uint8_t*>(scratch_buffer_handles_) !=
+      memory_allocator_->GetBuffer() - memory_allocator_->GetDataSize()) {
+    TF_LITE_REPORT_ERROR(error_reporter_,
+                         "Internal error: AllocateFromTail can not be called "
+                         "between two RequestScratchBufferInArena calls.");
+  }
+
+  internal::ScratchBufferHandle* handle =
+      reinterpret_cast<internal::ScratchBufferHandle*>(
+          memory_allocator_->AllocateFromTail(
+              sizeof(internal::ScratchBufferHandle),
+              alignof(internal::ScratchBufferHandle)));
+  if (handle == nullptr) {
+    TF_LITE_REPORT_ERROR(error_reporter_,
+                         "Failed to register scratch buffer handle for node %s",
+                         node_id);
+    return kTfLiteError;
+  }
+  *handle = {};
+  handle->bytes = bytes;
+  handle->node_idx = node_id;
+  *buffer_idx = scratch_buffer_count_;
+  scratch_buffer_count_ += 1;
+  // scratch_buffer_handles_ is in reverse order. The following code ensures that
+  // scratch_buffers[0] is pointing to the newly allocated handle.
+  scratch_buffer_handles_ = handle;
+  return kTfLiteOk;
+}
+
+void* MicroAllocator::GetScratchBuffer(int buffer_idx) const {
+  if (static_cast<size_t>(buffer_idx) >= scratch_buffer_count_) {
+    TF_LITE_REPORT_ERROR(error_reporter_,
+                         "Buffer %d not found. %d buffers available.",
+                         buffer_idx, scratch_buffer_count_);
+  }
+  // scratch_buffer_handles_ is in reverse order.
+  return scratch_buffer_handles_[scratch_buffer_count_ - buffer_idx - 1].data;
 }
 
 }  // namespace tflite

--- a/tensorflow/lite/micro/micro_allocator.h
+++ b/tensorflow/lite/micro/micro_allocator.h
@@ -25,12 +25,30 @@ namespace tflite {
 
 // Namespace used for unittests.
 namespace internal {
+
 // Sets up all of the data structure members for a runtime tensor
 // based on the contents of a serialized tensor.
 TfLiteStatus InitializeRuntimeTensor(
     SimpleMemoryAllocator* allocator, const tflite::Tensor& flatbuffer_tensor,
     const flatbuffers::Vector<flatbuffers::Offset<Buffer>>* buffers,
     ErrorReporter* error_reporter, TfLiteTensor* result);
+
+// A handle tracking scratch buffer allocation. This handle is created by
+// `RequestScratchBufferInArena`. `data` field is populated in
+// `FinishTensorAllocation` after static memory planning.
+// TODO(b/150257460) As a future optimization, this struct could be replaced by a
+// union, since once `data` is populated, `bytes` and `node_idx` is not needed.
+typedef struct {
+  // Pointer to the scratch buffer.
+  uint8_t* data;
+  // Number of bytes required by the buffer. The actual allocated size might be
+  // greater than `bytes` due to buffer alignment.
+  size_t bytes;
+  // Node where the buffer is allocated for. This provides useful information to
+  // determine the lifetime of the buffer. In AllocationInfo, this buffer will
+  // have `before` = node_idx and `after` = node_idx.
+  int node_idx;
+} ScratchBufferHandle;
 }  // namespace internal
 
 typedef struct {
@@ -40,6 +58,16 @@ typedef struct {
 
 // Allocator responsible for allocating memory for all intermediate tensors
 // necessary to invoke a model.
+
+// Memory layout to help understand how it works
+// This information could change in the future version.
+// ************** .memory_allocator->GetBuffer()
+// Tensors/Scratch buffers (head)
+// **************
+// unused memory
+// ************** .memory_allocator->GetBuffer() + ->GetDataSize()
+// persistent area (tail)
+// ************** .memory_allocator->GetBuffer() + ->GetMaxBufferSize()
 class MicroAllocator {
  public:
   // The lifetime of the model, tensor allocator and error reporter must be at
@@ -55,7 +83,7 @@ class MicroAllocator {
   // Runs through the model and allocates all necessary input, output and
   // intermediate tensors.
   // WARNING: doing any allocation after calling this method has the risk of
-  // corrupting tensor data so this method should be the last method to be
+  // corrupting tensor data so this method should be the last non-const method
   // called in this class.
   TfLiteStatus FinishTensorAllocation();
 
@@ -66,6 +94,22 @@ class MicroAllocator {
       const OpResolver& op_resolver,
       NodeAndRegistration** node_and_registrations);
 
+  // Allocates persistent buffer which has the same life time as the allocator.
+  // The memory is immediately available and is allocated from the tail of the
+  // arena.
+  TfLiteStatus AllocatePersistentBuffer(size_t bytes, void** ptr);
+
+  // Register a scratch buffer of size `bytes` for Node with `node_id`.
+  // This method only allocates a BufferHandle holding information for memory
+  // planning. The buffer ptr is ready after `FinishTensorAllocation` and can
+  // be retrieved by `GetScratchBuffer` method using the returned buffer_idx.
+  // Note that there should be no tail allocation between two consecutive
+  // `RequestScratchBufferInArena` calls.
+  TfLiteStatus RequestScratchBufferInArena(int node_id, size_t bytes,
+                                           int* buffer_idx);
+  // Returns the pointer to the planned scratch buffer.
+  void* GetScratchBuffer(int buffer_idx) const;
+
  private:
   TfLiteStatus Init();
 
@@ -75,6 +119,13 @@ class MicroAllocator {
   TfLiteContext* context_;
   // Indicating if the allocator is ready for allocation.
   bool active_ = false;
+
+  // In reverse order for efficiency.
+  // i.e. scratch_buffer_handles_[0] is the handle for the last buffer,
+  // corresponding to the last RequestScratchBufferInArena call.
+  internal::ScratchBufferHandle* scratch_buffer_handles_ = nullptr;
+  // How many scratch buffers have been allocated.
+  size_t scratch_buffer_count_ = 0;
 
   const SubGraph* subgraph_;
   const flatbuffers::Vector<flatbuffers::Offset<Operator>>* operators_;

--- a/tensorflow/lite/micro/micro_interpreter_test.cc
+++ b/tensorflow/lite/micro/micro_interpreter_test.cc
@@ -15,6 +15,9 @@ limitations under the License.
 
 #include "tensorflow/lite/micro/micro_interpreter.h"
 
+#include <cstdint>
+
+#include "tensorflow/lite/kernels/kernel_util.h"
 #include "tensorflow/lite/micro/micro_optional_debug_tools.h"
 #include "tensorflow/lite/micro/micro_utils.h"
 #include "tensorflow/lite/micro/test_helpers.h"
@@ -23,34 +26,126 @@ limitations under the License.
 namespace tflite {
 namespace {
 
-void* MockInit(TfLiteContext* context, const char* buffer, size_t length) {
-  // We don't support delegate in TFL micro. This is a weak check to test if
-  // context struct being zero-initialized.
-  TF_LITE_MICRO_EXPECT_EQ(nullptr,
-                          context->ReplaceNodeSubsetsWithDelegateKernels);
-  // Do nothing.
-  return nullptr;
-}
+// A simple operator that returns the median of the input with the number of
+// times the kernel was invoked. The implementation below is deliberately
+// complicated, just to demonstrate how kernel memory planning works.
+class SimpleStatefulOp {
+  static constexpr int kBufferNotAllocated = 0;
+  // Inputs:
+  static constexpr int kInputTensor = 0;
+  // Outputs:
+  static constexpr int kMedianTensor = 0;
+  static constexpr int kInvokeCount = 1;
+  struct OpData {
+    int invoke_count = 0;
+    int sorting_buffer = kBufferNotAllocated;
+  };
+
+ public:
+  static const TfLiteRegistration* getRegistration() {
+    static TfLiteRegistration r = {Init, /* free= */ nullptr, Prepare, Invoke};
+    return &r;
+  }
+
+  static void* Init(TfLiteContext* context, const char* buffer, size_t length) {
+    TF_LITE_MICRO_EXPECT_EQ(nullptr, context->RequestScratchBufferInArena);
+    TF_LITE_MICRO_EXPECT_EQ(nullptr, context->AllocateBufferForEval);
+    TF_LITE_MICRO_EXPECT_EQ(nullptr, context->GetScratchBuffer);
+
+    void* raw;
+    TF_LITE_MICRO_EXPECT_EQ(kTfLiteOk, context->AllocatePersistentBuffer(
+                                           context, sizeof(OpData), &raw));
+    OpData* data = reinterpret_cast<OpData*>(raw);
+    *data = {};
+    return raw;
+  }
+
+  static TfLiteStatus Prepare(TfLiteContext* context, TfLiteNode* node) {
+    OpData* data = reinterpret_cast<OpData*>(node->user_data);
+
+    // Make sure that the input is in uint8 with at least 1 data entry.
+    const TfLiteTensor* input = GetInput(context, node, kInputTensor);
+    if (input->type != kTfLiteUInt8) return kTfLiteError;
+    if (NumElements(input->dims) == 0) return kTfLiteError;
+
+    // Allocate a temporary buffer with the same size of input for sorting.
+    TF_LITE_ENSURE_STATUS(context->RequestScratchBufferInArena(
+        context, sizeof(uint8_t) * NumElements(input->dims),
+        &data->sorting_buffer));
+    return kTfLiteOk;
+  }
+
+  static TfLiteStatus Invoke(TfLiteContext* context, TfLiteNode* node) {
+    OpData* data = reinterpret_cast<OpData*>(node->user_data);
+    data->invoke_count += 1;
+
+    const TfLiteTensor* input = GetInput(context, node, kInputTensor);
+    const uint8_t* input_data = GetTensorData<uint8_t>(input);
+    int size = NumElements(input->dims);
+
+    uint8_t* sorting_buffer = reinterpret_cast<uint8_t*>(
+        context->GetScratchBuffer(context, data->sorting_buffer));
+    // Copy inputs data to the sorting buffer. We don't want to mutate the input
+    // tensor as it might be used by a another node.
+    for (int i = 0; i < size; i++) {
+      sorting_buffer[i] = input_data[i];
+    }
+
+    // In place insertion sort on `sorting_buffer`.
+    for (int i = 1; i < size; i++) {
+      for (int j = i; j > 0 && sorting_buffer[j] < sorting_buffer[j - 1]; j--) {
+        std::swap(sorting_buffer[j], sorting_buffer[j - 1]);
+      }
+    }
+
+    TfLiteTensor* median = GetOutput(context, node, kMedianTensor);
+    uint8_t* median_data = GetTensorData<uint8_t>(median);
+    TfLiteTensor* invoke_count = GetOutput(context, node, kInvokeCount);
+    int32_t* invoke_count_data = GetTensorData<int32_t>(invoke_count);
+
+    median_data[0] = sorting_buffer[size / 2];
+    invoke_count_data[0] = data->invoke_count;
+    return kTfLiteOk;
+  }
+};
 
 bool freed = false;
-void MockFree(TfLiteContext* context, void* buffer) { freed = true; }
 
-TfLiteStatus MockPrepare(TfLiteContext* context, TfLiteNode* node) {
-  return kTfLiteOk;
-}
+class MockCustom {
+ public:
+  static const TfLiteRegistration* getRegistration() {
+    static TfLiteRegistration r = {Init, Free, Prepare, Invoke};
+    return &r;
+  }
 
-TfLiteStatus MockInvoke(TfLiteContext* context, TfLiteNode* node) {
-  const TfLiteTensor* input = &context->tensors[node->inputs->data[0]];
-  const int32_t* input_data = input->data.i32;
-  const TfLiteTensor* weight = &context->tensors[node->inputs->data[1]];
-  const uint8_t* weight_data = weight->data.uint8;
-  TfLiteTensor* output = &context->tensors[node->outputs->data[0]];
-  int32_t* output_data = output->data.i32;
-  output_data[0] =
-      0;  // Catch output tensor sharing memory with an input tensor
-  output_data[0] = input_data[0] + weight_data[0];
-  return kTfLiteOk;
-}
+  static void* Init(TfLiteContext* context, const char* buffer, size_t length) {
+    // We don't support delegate in TFL micro. This is a weak check to test if
+    // context struct being zero-initialized.
+    TF_LITE_MICRO_EXPECT_EQ(nullptr,
+                            context->ReplaceNodeSubsetsWithDelegateKernels);
+    // Do nothing.
+    return nullptr;
+  }
+
+  static void Free(TfLiteContext* context, void* buffer) { freed = true; }
+
+  static TfLiteStatus Prepare(TfLiteContext* context, TfLiteNode* node) {
+    return kTfLiteOk;
+  }
+
+  static TfLiteStatus Invoke(TfLiteContext* context, TfLiteNode* node) {
+    const TfLiteTensor* input = &context->tensors[node->inputs->data[0]];
+    const int32_t* input_data = input->data.i32;
+    const TfLiteTensor* weight = &context->tensors[node->inputs->data[1]];
+    const uint8_t* weight_data = weight->data.uint8;
+    TfLiteTensor* output = &context->tensors[node->outputs->data[0]];
+    int32_t* output_data = output->data.i32;
+    output_data[0] =
+        0;  // Catch output tensor sharing memory with an input tensor
+    output_data[0] = input_data[0] + weight_data[0];
+    return kTfLiteOk;
+  }
+};
 
 class MockOpResolver : public OpResolver {
  public:
@@ -60,9 +155,9 @@ class MockOpResolver : public OpResolver {
   }
   const TfLiteRegistration* FindOp(const char* op, int version) const override {
     if (strcmp(op, "mock_custom") == 0) {
-      static TfLiteRegistration r = {MockInit, MockFree, MockPrepare,
-                                     MockInvoke};
-      return &r;
+      return MockCustom::getRegistration();
+    } else if (strcmp(op, "simple_stateful_op") == 0) {
+      return SimpleStatefulOp::getRegistration();
     } else {
       return nullptr;
     }
@@ -125,6 +220,45 @@ TF_LITE_MICRO_TEST(TestInterpreter) {
   }
 
   TF_LITE_MICRO_EXPECT_EQ(tflite::freed, true);
+}
+
+TF_LITE_MICRO_TEST(TestKernelMemoryPlanning) {
+  const tflite::Model* model = tflite::testing::GetSimpleStatefulModel();
+  TF_LITE_MICRO_EXPECT_NE(nullptr, model);
+  tflite::MockOpResolver mock_resolver;
+  constexpr size_t allocator_buffer_size = 1024;
+  uint8_t allocator_buffer[allocator_buffer_size];
+  tflite::MicroInterpreter interpreter(model, mock_resolver, allocator_buffer,
+                                       allocator_buffer_size,
+                                       micro_test::reporter);
+  TF_LITE_MICRO_EXPECT_EQ(interpreter.AllocateTensors(), kTfLiteOk);
+  TF_LITE_MICRO_EXPECT_EQ(1, interpreter.inputs_size());
+  TF_LITE_MICRO_EXPECT_EQ(2, interpreter.outputs_size());
+
+  TfLiteTensor* input = interpreter.input(0);
+  TF_LITE_MICRO_EXPECT_EQ(1, input->dims->size);
+  TF_LITE_MICRO_EXPECT_EQ(3, input->dims->data[0]);
+  input->data.uint8[0] = 2;
+  input->data.uint8[1] = 3;
+  input->data.uint8[2] = 1;
+
+  uint8_t expected_median = 2;
+
+  {
+    TF_LITE_MICRO_EXPECT_EQ(kTfLiteOk, interpreter.Invoke());
+    TfLiteTensor* median = interpreter.output(0);
+    TF_LITE_MICRO_EXPECT_EQ(expected_median, median->data.uint8[0]);
+    TfLiteTensor* invoke_count = interpreter.output(1);
+    TF_LITE_MICRO_EXPECT_EQ(1, invoke_count->data.i32[0]);
+  }
+
+  {
+    TF_LITE_MICRO_EXPECT_EQ(kTfLiteOk, interpreter.Invoke());
+    TfLiteTensor* median = interpreter.output(0);
+    TF_LITE_MICRO_EXPECT_EQ(expected_median, median->data.uint8[0]);
+    TfLiteTensor* invoke_count = interpreter.output(1);
+    TF_LITE_MICRO_EXPECT_EQ(2, invoke_count->data.i32[0]);
+  }
 }
 
 TF_LITE_MICRO_TEST(TestVariableTensorReset) {

--- a/tensorflow/lite/micro/test_helpers.h
+++ b/tensorflow/lite/micro/test_helpers.h
@@ -37,6 +37,9 @@ const Model* GetComplexMockModel();
 // Returns a simple flatbuffer model with two branches.
 const Model* GetSimpleModelWithBranch();
 
+// Returns a flatbuffer model with `simple_stateful_op`
+const Model* GetSimpleStatefulModel();
+
 // Builds a one-dimensional flatbuffer tensor of the given size.
 const Tensor* Create1dFlatbufferTensor(int size, bool is_variable = false);
 


### PR DESCRIPTION
A few things to notice.
- ContextHelper is a helper class reducing the overload on the interpreter. It forwards the request to the allocator while keep tracking the latest node ID. 
- Buffers have are located in different areas due to their different lifespan. persistent buffers and scratch buffer handles need to be allocated from the persistent area (tail). Scratch buffers sit together with other tensors (head).
- Buffer handles are located in a "stack". The most recent buffer handle has the lowest address. This optimization saves us from reversing the order of buffer handles list.